### PR TITLE
Support for copying label descriptions

### DIFF
--- a/githublabelscopy/githublabelscopy.py
+++ b/githublabelscopy/githublabelscopy.py
@@ -6,7 +6,7 @@ This allow you to copy and/or update labels from a source repository
 to another.
 
 Usage:
-  github-labels-copy [--login=<login> | --token=<token>] [-crm]
+  github-labels-copy [--login=<login> | --token=<token>] [-crms]
                      (--load=<file> | SOURCE) (--dump | DESTINATION)
   github-labels-copy (-h | --help)
   github-labels-copy --version
@@ -28,6 +28,8 @@ Options:
                     repository.
   -m                Modify labels existing in both repositories but with a
                     different color.
+  -s                Modify descriptions existing in both repositories but
+                    with different content.
 
 """
 
@@ -77,8 +79,10 @@ def label_copy():
     if args['-r']:
         labels.deleteBad()
     if args['-m']:
-        labels.updateWrong()
-    if not args['-c'] and not args['-r'] and not args['-m']:
+        labels.updateWrongColors()
+    if args['-s']:
+        labels.updateWrongDescriptions()
+    if not args['-c'] and not args['-r'] and not args['-m'] and not args['-s']:
         labels.fullCopy()
 
     if args['--dump']:

--- a/requirements
+++ b/requirements
@@ -1,3 +1,3 @@
 docopt==0.6.2
-PyGithub==1.34
+PyGithub==1.55
 PyYAML==3.12

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name='githublabelscopy',
       packages=['githublabelscopy'],
       long_description=open('README.rst').read(),
       install_requires=[
-          'PyGithub==1.34',
+          'PyGithub==1.55',
           'docopt==0.6.2',
           'PyYAML==3.12'
       ],


### PR DESCRIPTION
Added support for also copying the description of a label from the source repo to the target repo, as mentioned in #8.

An upgrade to PyGithub from 1.34 to 1.55 appeared to be required to access the label description.